### PR TITLE
add verbose error output

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -157,6 +157,7 @@ class DSpaceClient:
                 return r_json['authenticated']
 
         # Default, return false
+        _logger.error(f'Requestes url:{r.url}; status code:{r.status_code}; text:{r.text}')
         return False
 
     def refresh_token(self):


### PR DESCRIPTION
Be more helpful in case of errors, e.g. an error 500 (because of an extra '/' should not be misread as an "ConnectionError: Cannot authenticate to dspace!"). Output `r.url, r.status_code, r.text`:
```
ERROR: Requestes url:https://HOST/repository/server/api//authn/status; status code:500; text:{"timestamp"
:"2025-07-07T08:53:24.119+00:00","status":500,"error":"Internal Server Error","message":"The request was rejected because the URL contained a potentiall
y malicious String \"//\"","path":"/repository/server/api//authn/status"}
```